### PR TITLE
Grunt traceur fixes

### DIFF
--- a/collectbook/Gruntfile.js
+++ b/collectbook/Gruntfile.js
@@ -58,7 +58,7 @@ module.exports = function (grunt) {
     traceur: {
       options: {
         includeRuntime: true, // includes runtime code in generated file
-        traceurOptions: '--experimental --sourcemap'
+        traceurOptions: '--experimental --source-maps=file'
       },
       server: {
         files: {

--- a/collectbook/app.js
+++ b/collectbook/app.js
@@ -11,12 +11,12 @@ var app = angular.module('CollectBook',
   ['cb-directives', 'cb-filters', 'ui.router']);
 
 // These are ES6 imports of other JavaScript source files.
-import './features/directives/main';
-import './features/edit-book/edit-book';
-import './features/filters/main';
-import './features/nav/nav';
-import './features/new-book/new-book';
-import './features/view-book/view-book';
+import './features/directives/main.js';
+import './features/edit-book/edit-book.js';
+import './features/filters/main.js';
+import './features/nav/nav.js';
+import './features/new-book/new-book.js';
+import './features/view-book/view-book.js';
 
 // This is the prefix for all REST URLs used by this app.
 var URL_PREFIX = 'http://localhost:3000/collectbook/';

--- a/collectbook/features/directives/main.js
+++ b/collectbook/features/directives/main.js
@@ -5,9 +5,9 @@
 var mod = angular.module('cb-directives', []);
 
 // ES6 imports of files that add to this module.
-import './color-picker';
-import './dialog';
-import './keys';
+import './color-picker.js';
+import './dialog.js';
+import './keys.js';
 
 mod.byId = function (id) {
   return angular.element(document.getElementById(id));

--- a/collectbook/features/edit-book/edit-book.js
+++ b/collectbook/features/edit-book/edit-book.js
@@ -4,7 +4,7 @@
 
 var app = angular.module('CollectBook');
 
-import Field from '../models/field';
+import Field from '../models/field.js';
 
 app.config(($stateProvider) => {
   $stateProvider.

--- a/collectbook/features/filters/main.js
+++ b/collectbook/features/filters/main.js
@@ -5,5 +5,5 @@
 var mod = angular.module('cb-filters', ['ngSanitize']);
 
 // ES6 imports of files that add to this module.
-import './obj-to-arr';
-import './raw';
+import './obj-to-arr.js';
+import './raw.js';

--- a/collectbook/features/models/book.js
+++ b/collectbook/features/models/book.js
@@ -1,7 +1,7 @@
 'use strict';
 /*jshint esnext: true */
 
-import {camelCase} from '../share/string-util';
+import {camelCase} from '../share/string-util.js';
 
 class Book {
   constructor() {

--- a/collectbook/features/models/field.js
+++ b/collectbook/features/models/field.js
@@ -1,7 +1,7 @@
 'use strict';
 /*jshint esnext: true */
 
-import {camelCase} from '../share/string-util';
+import {camelCase} from '../share/string-util.js';
 
 class Field {
   constructor() {

--- a/collectbook/features/new-book/new-book.js
+++ b/collectbook/features/new-book/new-book.js
@@ -2,7 +2,7 @@
 /*jshint esnext: true */
 /*global angular: false */
 
-import Book from '../models/book';
+import Book from '../models/book.js';
 
 var app = angular.module('CollectBook');
 

--- a/collectbook/features/view-book/view-book.js
+++ b/collectbook/features/view-book/view-book.js
@@ -4,7 +4,7 @@
 
 var app = angular.module('CollectBook');
 
-import Item from '../models/item';
+import Item from '../models/item.js';
 
 // These are types whose name matches that of
 // a valid HTML5 input type attribute value.

--- a/collectbook/server.js
+++ b/collectbook/server.js
@@ -12,13 +12,13 @@
  */
 
 // ES6 imports
-import Book from './features/models/book';
-import Field from './features/models/field';
+import Book from './features/models/book.js';
+import Field from './features/models/field.js';
 
 // fs-promise wraps a subset of the functions in the Node.js fs module
 // so they use ES6 promises.
 import {exists, isDirectory, mkdir, readDir, readObject, rm, rmdir, writeObject}
-  from './features/share/fs-promise';
+  from './features/share/fs-promise.js';
 
 var express = require('express');
 var path = require('path');


### PR DESCRIPTION
I had some issues in the traceur section of the grunt build.
- --sourcemap isn't a valid command line option
- import statements failed if they don't include the '.js' extension.

I didn't do much research into either of these.  There may be better solutions available.
